### PR TITLE
Fix tests e2e event modificacion botones Cerrar Sesion y Crear Evento

### DIFF
--- a/app/test/test_e2e/test_events.py
+++ b/app/test/test_e2e/test_events.py
@@ -247,7 +247,7 @@ class EventPermissionsTest(EventBaseTest):
         expect(create_button).to_be_visible()
 
         # Cerrar sesión
-        self.page.get_by_role("button", name="Salir").click()
+        self.page.get_by_role("button", name="Cerrar Sesión").click()
 
         # Iniciar sesión como usuario regular
         self.login_user("usuario", "password123")
@@ -290,7 +290,7 @@ class EventCRUDTest(EventBaseTest):
         self.page.check(f"input[name='categories'][value='{self.category.id}']") # type: ignore
 
         # Enviar el formulario
-        self.page.get_by_role("button", name="Editar Evento").click()
+        self.page.get_by_role("button", name="Crear Evento").click()
 
         # Verificar que redirigió a la página de eventos
         expect(self.page).to_have_url(f"{self.live_server_url}/events/")

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ tomli==2.2.1
 typing_extensions==4.13.2
 tzdata==2025.2
 urllib3==2.4.0
+Babel>=2.0


### PR DESCRIPTION
## Cambios realizados
- **Corrección de selectores en tests E2E:**  
  - Se ajustó el rol y texto del botón "Cerrar Sesión" en lugar de "Salir" para coincidir con el HTML
  - Se ajusto el boton "Crear Evento" correctamente

## Problemas resueltos
- **Error en test `test_buttons_visible_only_for_organizer`:**  
  El test fallaba porque el botón de logout no se encontraba debido a un selector incorrecto.
  
## Cómo probar los cambios
Ejecutar los tests E2E:
python manage.py test app.test.test_e2e.test_events