### PR TITLE
add: funcionalidad limitar entradas a usuarios por evento

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -229,6 +229,12 @@ class Ticket(models.Model):
             self.ticket_code = str(uuid.uuid4()).replace('-', '')[:10].upper()
         super().save(*args, **kwargs)
 
+    @classmethod
+    def entradas_disponibles_para_usuario(cls, user, event):
+        cantidad_actual = cls.objects.filter(user=user, event=event).aggregate(models.Sum('quantity'))['quantity__sum'] or 0
+        return 4 - cantidad_actual
+
+
 # ------------------- Notificación -------------------
 class Notification(models.Model):
     # Destinatario específico (opcional)

--- a/app/static/js/ticket.js
+++ b/app/static/js/ticket.js
@@ -89,6 +89,18 @@ function validarPago() {
     return false;
   }
 
+  const cantidad = parseInt(document.getElementById("id_quantity").value);
+  const max = parseInt(document.getElementById("id_quantity").dataset.max || 4);
+  if (cantidad > max) {
+    Swal.fire({
+      title: 'Error',
+      text: `Solo puedes comprar ${max} entrada/s para este evento.`,
+      icon: 'error',
+      confirmButtonText: 'Aceptar'
+    });
+    return false;
+  }
+
   return true;  // Si todo está bien, se envía el formulario
 }
 

--- a/app/static/js/ticket.js
+++ b/app/static/js/ticket.js
@@ -109,6 +109,7 @@ window.addEventListener("DOMContentLoaded", () => {
   formatearNumerosTarjeta(document.getElementById("card_number"));
   formatearFechaExp(document.getElementById("card_expiry"));
   validarCVV(document.getElementById("card_cvv"));
+  validarNombre(document.getElementById("card_name"));
 });
 
 function formatearNumerosTarjeta (input){
@@ -138,5 +139,12 @@ function validarCVV (input){
     let cvv = input.value.replace (/\D/g, "").substring (0,3);
     input.value = cvv;
 
+  })
+}
+
+function validarNombre (input){
+  input.addEventListener("input", () => {
+    let nombre = input.value.replace(/[^a-zA-ZáéíóúÁÉÍÓÚñÑ\s]/g, "");
+    input.value = nombre;
   })
 }

--- a/app/templates/app/ticket/ticket_form.html
+++ b/app/templates/app/ticket/ticket_form.html
@@ -101,6 +101,12 @@
         <div class="card-body small">
           <ul class="mb-0">
             <li>Las entradas son personales e intransferibles.</li>
+            <li>Maximo 4 entradas por evento.</li>
+            <li>{% if entradas_existentes > 0 %}
+                  Ya has comprado {{ entradas_existentes }} para este evento.
+                {% else %}
+                  Aún no has comprado entradas para este evento.
+                {% endif %}</li>
             <li>Puedes solicitar un reembolso hasta 48 horas antes del evento.</li>
             <li>Recibirás tu entrada en tu correo electrónico.</li>
             <li>Presenta tu entrada digital o impresa el día del evento.</li>

--- a/app/templates/app/ticket/ticket_list_organizer.html
+++ b/app/templates/app/ticket/ticket_list_organizer.html
@@ -16,7 +16,7 @@
                         <li class="list-group-item d-flex justify-content-between align-items-center">
                             <div>
                                 <strong>{{ ticket.user.username }}</strong> compró un ticket de tipo 
-                                <strong>{{ ticket.get_ticket_type_display }}</strong><br>
+                                <strong>{{ ticket.get_type_display }}</strong><br>
                                 <small class="text-muted">Fecha de compra: {{ ticket.buy_date }}</small>
                             </div>
                             <span>

--- a/app/views.py
+++ b/app/views.py
@@ -606,6 +606,7 @@ def ticket_create(request, event_id):
         form = TicketForm()
         disponibles = Ticket.entradas_disponibles_para_usuario(request.user, event)
         existentes = 4 - disponibles
+        form.fields['quantity'].widget.attrs['data-max'] = disponibles
 
     return render(request, 'app/ticket/ticket_form.html', {
         'form': form,

--- a/app/views.py
+++ b/app/views.py
@@ -584,14 +584,34 @@ def ticket_create(request, event_id):
             ticket = form.save(commit=False)
             ticket.event = event
             ticket.user = request.user
+
+            disponibles = Ticket.entradas_disponibles_para_usuario(request.user, event)
+            existentes = 4 - disponibles
+
+            if ticket.quantity > disponibles:
+                messages.error(
+                    request,
+                    f"No puedes comprar más de 4 entradas por evento. Ya compraste {existentes}."
+                )
+                return render(request, 'app/ticket/ticket_form.html', {
+                    'form': form,
+                    'event': event,
+                    'entradas_existentes': existentes,
+                    'entradas_disponibles': disponibles,
+                })
+
             ticket.save()
             return redirect('ticket_list')
     else:
         form = TicketForm()
+        disponibles = Ticket.entradas_disponibles_para_usuario(request.user, event)
+        existentes = 4 - disponibles
 
     return render(request, 'app/ticket/ticket_form.html', {
         'form': form,
-        'event': event
+        'event': event,
+        'entradas_existentes': existentes,
+        'entradas_disponibles': disponibles,
     })
 
 


### PR DESCRIPTION
**Pull Request: Límite de entradas por usuario y validaciones visuales**

### Cambios realizados:

* Se implementó una regla para limitar a **4 entradas por usuario por evento**.
* Se validan las entradas ya compradas por el usuario antes de permitir nuevas compras.
* Se actualiza dinámicamente la cantidad máxima permitida usando el atributo `data-max` en el formulario.
* Se muestra un mensaje en el formulario indicando cuántas entradas ha comprado el usuario previamente.
* Se muestra una alerta visual con **SweetAlert** si el usuario intenta superar el límite de entradas.
* Se agregó lógica del lado del **backend** para prevenir compras mayores a lo permitido, incluso si se saltean las validaciones del frontend.

### Cómo probar los cambios:

1. Ir a la pantalla de compra de entradas.
2. Realizar una compra de X entradas (por ejemplo, 2).
3. Intentar comprar más de 2 entradas para el mismo evento → el sistema debe impedirlo y mostrar un mensaje claro.
4. El resumen debe actualizarse y mostrar:

   * Límite máximo por usuario.
   * Cantidad ya adquirida.
5. El límite se valida tanto en el **JavaScript del cliente** como en el **servidor** para mayor seguridad.
