### PR TITLE
add: job de test e2e y notificación a discord

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -127,3 +127,57 @@ jobs:
       - name: Verificar configuración de deployment
         run: |
           python manage.py check --deploy
+
+  e2e-test:
+    runs-on: ubuntu-latest
+    needs: integration-test
+
+    steps:
+      - name: Checkout código
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Instalar dependencias
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Crear archivo .env para E2E
+        run: |
+          cat > .env << EOF
+          SECRET_KEY=e2e-secret-key
+          DEBUG=False
+          ALLOWED_HOSTS=localhost,127.0.0.1
+          DATABASE_NAME=e2e_test_db.sqlite3
+          EOF
+
+      - name: Ejecutar migraciones
+        run: python manage.py migrate
+
+      - name: Ejecutar test E2E
+        run: |
+          mkdir -p static
+          python manage.py test app.test.test_e2e --verbosity=2
+
+  notify-discord:
+    runs-on: ubuntu-latest
+    needs: e2e-test
+    steps:
+      - name: Enviar mensaje a discord
+        run: | 
+          curl -H "Content-Type: application/json" \
+          -X POST \
+          -d "{\"content\": \"Se completo el CI correctamente en la rama $GITHUB_REF por $GITHUB_ACTOR\"}" \
+          ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
# Resuelve #30 

## Descripción

Agrega los tests end-to-end al flujo de integración continua (CI), y configura la notificación automática al canal de Discord del equipo una vez que el pipeline se ejecuta correctamente.

## Tareas realizadas

- Implementación del job `e2e-test` que ejecuta los tests end-to-end definidos en `app.test.test_e2e`, utilizando su propio entorno `.env` y base de datos de pruebas.
- Integración del job `e2e-test` al pipeline, con dependencias establecidas (`needs: integration-test`).
- Implementación del job `notify-discord` que envía un mensaje automático a Discord al finalizar correctamente el pipeline.
- Configuración de la variable secreta `DISCORD_WEBHOOK_URL` para mantener segura la URL del webhook de Discord.
- Pruebas locales del webhook mediante PowerShell para validar su funcionamiento antes de integrarlo en GitHub Actions.

## Criterios de aceptación

- El job `e2e-test` se ejecuta automáticamente después del job `integration-test`.
- Los tests end-to-end pasan correctamente, utilizando un entorno de prueba aislado.
- El job `notify-discord` se ejecuta únicamente si todos los jobs anteriores (build, test, integración y E2E) pasan correctamente.
- El mensaje se envía al canal de Discord correspondiente utilizando el webhook definido en los Secrets del repositorio.

