### PR TITLE
Feature/35 discord notifications

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,9 +53,9 @@ jobs:
 
       - name: Deploy to ${{ github.event_name == 'pull_request' && 'Preview' || 'Production' }} Environment
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             curl -X POST ${{ secrets.RENDER_PREVIEW_DEPLOY_HOOK_URL }}
-          elif [ "${{ github.event_name }}" = "release" ]; then
+          elif [ "$GITHUB_EVENT_NAME" = "release" ]; then
             curl -X POST ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
           fi
 
@@ -68,10 +68,10 @@ jobs:
 
       - name: Verificar que la app esté online
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
             curl -f https://eventhub-g15.onrender.com
           else
-            curl -f https://eventhub-preview.onrender.com
+            curl -f https://eventhub-g15-pre.onrender.com
           fi
 
   notify-deployment:
@@ -83,7 +83,12 @@ jobs:
       - name: Notificar deploy exitoso
         if: needs.verify-deployment.result == 'success'
         run: |
-          URL=$([[ "${{ github.event_name }}" == "release" ]] && echo "https://eventhub-g15.onrender.com" || echo "https://eventhub-preview.onrender.com")
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            URL="https://eventhub-g15.onrender.com"
+          else
+            URL="https://eventhub-g15-pre.onrender.com"
+          fi
+
           curl -H "Content-Type: application/json" \
           -X POST \
           -d "{
@@ -92,9 +97,9 @@ jobs:
               \"description\": \"La aplicación EventHub se ha desplegado correctamente en Render\",
               \"color\": 3066993,
               \"fields\": [
-                {\"name\": \"Rama\", \"value\": \"${{ github.ref_name }}\", \"inline\": true},
-                {\"name\": \"Commit\", \"value\": \"${{ github.sha }}\", \"inline\": true},
-                {\"name\": \"Actor\", \"value\": \"${{ github.actor }}\", \"inline\": true},
+                {\"name\": \"Rama\", \"value\": \"${GITHUB_REF_NAME}\", \"inline\": true},
+                {\"name\": \"Commit\", \"value\": \"${GITHUB_SHA}\", \"inline\": true},
+                {\"name\": \"Actor\", \"value\": \"${GITHUB_ACTOR}\", \"inline\": true},
                 {\"name\": \"URL\", \"value\": \"$URL\", \"inline\": false}
               ],
               \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
@@ -105,7 +110,12 @@ jobs:
       - name: Notificar deploy fallido
         if: needs.verify-deployment.result == 'failure'
         run: |
-          URL=$([[ "${{ github.event_name }}" == "release" ]] && echo "https://eventhub-g15.onrender.com" || echo "https://eventhub-preview.onrender.com")
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            URL="https://eventhub-g15.onrender.com"
+          else
+            URL="https://eventhub-g15-pre.onrender.com"
+          fi
+
           curl -H "Content-Type: application/json" \
           -X POST \
           -d "{
@@ -114,10 +124,10 @@ jobs:
               \"description\": \"El deploy de EventHub en Render ha fallado\",
               \"color\": 15158332,
               \"fields\": [
-                {\"name\": \"Rama\", \"value\": \"${{ github.ref_name }}\", \"inline\": true},
-                {\"name\": \"Commit\", \"value\": \"${{ github.sha }}\", \"inline\": true},
-                {\"name\": \"Actor\", \"value\": \"${{ github.actor }}\", \"inline\": true},
-                {\"name\": \"Logs\", \"value\": \"[Ver logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\", \"inline\": false},
+                {\"name\": \"Rama\", \"value\": \"${GITHUB_REF_NAME}\", \"inline\": true},
+                {\"name\": \"Commit\", \"value\": \"${GITHUB_SHA}\", \"inline\": true},
+                {\"name\": \"Actor\", \"value\": \"${GITHUB_ACTOR}\", \"inline\": true},
+                {\"name\": \"Logs\", \"value\": \"[Ver logs](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})\", \"inline\": false},
                 {\"name\": \"URL\", \"value\": \"$URL\", \"inline\": false}
               ],
               \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,3 +59,15 @@ jobs:
           elif [ "${{ github.event_name }}" = "release" ]; then
             curl -X POST ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
           fi
+
+  notify-discord:
+    runs-on: ubuntu-latest
+    needs: build-and-deploy
+    steps:
+      - name: Notificar a Discord sobre el deployment
+        run: |
+          ENVIRONMENT=$([[ "${{ github.event_name }}" == "pull_request" ]] && echo "Preview" || echo "Production")
+          curl -H "Content-Type: application/json" \
+          -X POST \
+          -d "{\"content\": \"🚀 Deployment exitoso en *$ENVIRONMENT* por $GITHUB_ACTOR\"}" \
+          ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,7 +51,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Deploy según el evento
       - name: Deploy to ${{ github.event_name == 'pull_request' && 'Preview' || 'Production' }} Environment
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -68,7 +67,12 @@ jobs:
         run: sleep 10
 
       - name: Verificar que la app esté online
-        run: curl -f https://eventhub-g15.onrender.com
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            curl -f https://eventhub-g15.onrender.com
+          else
+            curl -f https://eventhub-preview.onrender.com
+          fi
 
   notify-deployment:
     runs-on: ubuntu-latest
@@ -79,6 +83,7 @@ jobs:
       - name: Notificar deploy exitoso
         if: needs.verify-deployment.result == 'success'
         run: |
+          URL=$([[ "${{ github.event_name }}" == "release" ]] && echo "https://eventhub-g15.onrender.com" || echo "https://eventhub-preview.onrender.com")
           curl -H "Content-Type: application/json" \
           -X POST \
           -d "{
@@ -90,7 +95,7 @@ jobs:
                 {\"name\": \"Rama\", \"value\": \"${{ github.ref_name }}\", \"inline\": true},
                 {\"name\": \"Commit\", \"value\": \"${{ github.sha }}\", \"inline\": true},
                 {\"name\": \"Actor\", \"value\": \"${{ github.actor }}\", \"inline\": true},
-                {\"name\": \"URL\", \"value\": \"https://eventhub-g15.onrender.com\", \"inline\": false}
+                {\"name\": \"URL\", \"value\": \"$URL\", \"inline\": false}
               ],
               \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
             }]
@@ -100,6 +105,7 @@ jobs:
       - name: Notificar deploy fallido
         if: needs.verify-deployment.result == 'failure'
         run: |
+          URL=$([[ "${{ github.event_name }}" == "release" ]] && echo "https://eventhub-g15.onrender.com" || echo "https://eventhub-preview.onrender.com")
           curl -H "Content-Type: application/json" \
           -X POST \
           -d "{
@@ -111,7 +117,8 @@ jobs:
                 {\"name\": \"Rama\", \"value\": \"${{ github.ref_name }}\", \"inline\": true},
                 {\"name\": \"Commit\", \"value\": \"${{ github.sha }}\", \"inline\": true},
                 {\"name\": \"Actor\", \"value\": \"${{ github.actor }}\", \"inline\": true},
-                {\"name\": \"Logs\", \"value\": \"[Ver logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\", \"inline\": false}
+                {\"name\": \"Logs\", \"value\": \"[Ver logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\", \"inline\": false},
+                {\"name\": \"URL\", \"value\": \"$URL\", \"inline\": false}
               ],
               \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
             }]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Continuous Delivery
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   release:
     types: [published]
 
@@ -26,7 +26,7 @@ jobs:
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3
-        with: 
+        with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
@@ -60,14 +60,60 @@ jobs:
             curl -X POST ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
           fi
 
-  notify-discord:
+  verify-deployment:
     runs-on: ubuntu-latest
     needs: build-and-deploy
     steps:
-      - name: Notificar a Discord sobre el deployment
+      - name: Esperar que Render levante
+        run: sleep 10
+
+      - name: Verificar que la app esté online
+        run: curl -f https://eventhub-g15.onrender.com
+
+  notify-deployment:
+    runs-on: ubuntu-latest
+    needs: [verify-deployment]
+    if: always()
+
+    steps:
+      - name: Notificar deploy exitoso
+        if: needs.verify-deployment.result == 'success'
         run: |
-          ENVIRONMENT=$([[ "${{ github.event_name }}" == "pull_request" ]] && echo "Preview" || echo "Production")
           curl -H "Content-Type: application/json" \
           -X POST \
-          -d "{\"content\": \"🚀 Deployment exitoso en *$ENVIRONMENT* por $GITHUB_ACTOR\"}" \
+          -d "{
+            \"embeds\": [{
+              \"title\": \"🚀 Deploy Exitoso\",
+              \"description\": \"La aplicación EventHub se ha desplegado correctamente en Render\",
+              \"color\": 3066993,
+              \"fields\": [
+                {\"name\": \"Rama\", \"value\": \"${{ github.ref_name }}\", \"inline\": true},
+                {\"name\": \"Commit\", \"value\": \"${{ github.sha }}\", \"inline\": true},
+                {\"name\": \"Actor\", \"value\": \"${{ github.actor }}\", \"inline\": true},
+                {\"name\": \"URL\", \"value\": \"https://eventhub-g15.onrender.com\", \"inline\": false}
+              ],
+              \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+            }]
+          }" \
+          ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+      - name: Notificar deploy fallido
+        if: needs.verify-deployment.result == 'failure'
+        run: |
+          curl -H "Content-Type: application/json" \
+          -X POST \
+          -d "{
+            \"embeds\": [{
+              \"title\": \"❌ Deploy Fallido\",
+              \"description\": \"El deploy de EventHub en Render ha fallado\",
+              \"color\": 15158332,
+              \"fields\": [
+                {\"name\": \"Rama\", \"value\": \"${{ github.ref_name }}\", \"inline\": true},
+                {\"name\": \"Commit\", \"value\": \"${{ github.sha }}\", \"inline\": true},
+                {\"name\": \"Actor\", \"value\": \"${{ github.actor }}\", \"inline\": true},
+                {\"name\": \"Logs\", \"value\": \"[Ver logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\", \"inline\": false}
+              ],
+              \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+            }]
+          }" \
           ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,8 +84,10 @@ jobs:
         if: needs.verify-deployment.result == 'success'
         run: |
           if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            ENVIRONMENT="Production"
             URL="https://eventhub-g15.onrender.com"
           else
+            ENVIRONMENT="Preview"
             URL="https://eventhub-g15-pre.onrender.com"
           fi
 
@@ -97,6 +99,7 @@ jobs:
               \"description\": \"La aplicación EventHub se ha desplegado correctamente en Render\",
               \"color\": 3066993,
               \"fields\": [
+                {\"name\": \"Entorno\", \"value\": \"$ENVIRONMENT\", \"inline\": true},
                 {\"name\": \"Rama\", \"value\": \"${GITHUB_REF_NAME}\", \"inline\": true},
                 {\"name\": \"Commit\", \"value\": \"${GITHUB_SHA}\", \"inline\": true},
                 {\"name\": \"Actor\", \"value\": \"${GITHUB_ACTOR}\", \"inline\": true},
@@ -111,8 +114,10 @@ jobs:
         if: needs.verify-deployment.result == 'failure'
         run: |
           if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            ENVIRONMENT="Production"
             URL="https://eventhub-g15.onrender.com"
           else
+            ENVIRONMENT="Preview"
             URL="https://eventhub-g15-pre.onrender.com"
           fi
 
@@ -124,6 +129,7 @@ jobs:
               \"description\": \"El deploy de EventHub en Render ha fallado\",
               \"color\": 15158332,
               \"fields\": [
+                {\"name\": \"Entorno\", \"value\": \"$ENVIRONMENT\", \"inline\": true},
                 {\"name\": \"Rama\", \"value\": \"${GITHUB_REF_NAME}\", \"inline\": true},
                 {\"name\": \"Commit\", \"value\": \"${GITHUB_SHA}\", \"inline\": true},
                 {\"name\": \"Actor\", \"value\": \"${GITHUB_ACTOR}\", \"inline\": true},


### PR DESCRIPTION
Resuelve #35 

## 📝 Descripción
Agrega una notificación automática al canal de Discord del equipo cuando finaliza exitosamente el proceso de despliegue (CD), indicando si fue a Preview o Production, según el tipo de evento que disparó el workflow.

---

## ✅ Tareas realizadas
- Implementación del job `notify-discord` en el archivo `cd.yml`.
- Configuración para que el job se ejecute únicamente si `build-and-deploy` finaliza exitosamente (`needs: build-and-deploy`).
- Generación dinámica del tipo de entorno (`Preview` o `Production`) según si el evento fue `pull_request` o `release`.
- Envío de mensaje automático a Discord con el nombre del entorno, el usuario que activó el pipeline y un ícono de despliegue exitoso.
- Uso de la variable secreta `DISCORD_WEBHOOK_URL` para proteger el webhook de Discord.

---

## 🎯 Criterios de aceptación
- El job `notify-discord` se ejecuta automáticamente luego de `build-and-deploy`.
- El mensaje enviado incluye el entorno (`Preview` o `Production`) y el usuario (`$GITHUB_ACTOR`) que realizó la acción.
- El mensaje solo se envía si el job de despliegue fue exitoso.
- No se rompe ni interfiere con el flujo actual de CD.

