### PR TITLE
fix:  Entrega Continua depende de la Integración Continua

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,10 @@ on:
     branches: [ "main" ]
   release:
     types: [published]
+  workflow_run:
+    workflows: ["CI - Build and Test"]
+    types:
+      - completed
 
 env:
   REGISTRY: docker.io
@@ -16,6 +20,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: ["main"]
   release:
-    types: [published]
+    types: [published, created, edited]
   workflow_run:
     workflows: ["CI - Build and Test"]
     types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI - Build and Test
 on:
   pull_request:
     branches: [main]
+  release:
+    types: [published, created, edited]
 
 jobs:
   build:

--- a/l
+++ b/l
@@ -1,0 +1,11 @@
+  crud-venue[m
+  feature/13-hide-past-events[m
+  feature/2-event-countdown[m
+  feature/7-discount-code[m
+  feature/dockerfile-ci-build-setup[m
+  feature/event[m
+  feature/refunds[m
+  feature/release-tag[m
+* [32mfix/cd-setup[m
+  fix/project-structure[m
+  main[m


### PR DESCRIPTION
### Se corrige la configuración de entrega continua (CD) para que dependa correctamente de la integración continua (CI).

La entrega continua debe ejecutarse solo si la integración continua fue exitosa. Esto garantiza que solo versiones estables y validadas lleguen a los entornos de staging (preview) o producción.